### PR TITLE
Make sure the spoon form values are escaped when rendering the inputs

### DIFF
--- a/spoon/form/date.php
+++ b/spoon/form/date.php
@@ -377,7 +377,7 @@ class SpoonFormDate extends SpoonFormInput
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a date field. Please provide a valid name.');
 
 		// start html generation
-		$output = '<input type="text" value="' . $this->getValue() . '"';
+		$output = '<input type="text" value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
 
 		// add attributes
 		$output .= $this->getAttributesHTML(array('[id]' => $this->attributes['id'], '[name]' => $this->attributes['name'], '[value]' => $this->getValue())) . ' />';

--- a/spoon/form/hidden.php
+++ b/spoon/form/hidden.php
@@ -109,7 +109,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 	public function parse($template = null)
 	{
 		// start html generation
-		$output = '<input type="hidden" value="' . $this->getValue() . '"';
+		$output = '<input type="hidden" value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
 
 		// build attributes
 		$attributes = array();

--- a/spoon/form/password.php
+++ b/spoon/form/password.php
@@ -273,7 +273,7 @@ class SpoonFormPassword extends SpoonFormInput
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a password field. Please provide a name.');
 
 		// start html generation
-		$output = '<input type="password" value="' . str_replace(array('"', '<', '>'), array('&quot;', '&lt;', '&gt;'), $this->getValue()) . '"';
+		$output = '<input type="password" value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
 
 		// add attributes
 		$output .= $this->getAttributesHTML(array('[id]' => $this->attributes['id'], '[name]' => $this->attributes['name'], '[value]' => $this->getValue())) . ' />';

--- a/spoon/form/text.php
+++ b/spoon/form/text.php
@@ -788,7 +788,7 @@ class SpoonFormText extends SpoonFormInput
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a textfield. Please provide a name.');
 
 		// start html generation
-		$output = '<input value="' . str_replace(array('"', '<', '>'), array('&quot;', '&lt;', '&gt;'), $this->getValue()) . '"';
+		$output = '<input value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
 
 		// add attributes
 		$output .= $this->getAttributesHTML(array('[id]' => $this->attributes['id'], '[name]' => $this->attributes['name'], '[value]' => $this->getValue())) . ' />';

--- a/spoon/form/time.php
+++ b/spoon/form/time.php
@@ -216,7 +216,7 @@ class SpoonFormTime extends SpoonFormInput
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a time field. Please provide a name.');
 
 		// start html generation
-		$output = '<input type="text" value="' . $this->getValue() . '"';
+		$output = '<input type="text" value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
 
 		// add attributes
 		$output .= $this->getAttributesHTML(array('[id]' => $this->attributes['id'], '[name]' => $this->attributes['name'], '[value]' => $this->getValue())) . ' />';


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-spoon/library

### ⚙️ Description *

_Describe your fix clearly and concisely - imagine you are describing it to a non-technical friend._
The form input types time, date and hidden didn't escape the value during the rendering

### 💻 Technical Description *

_Describe in-depth, the technical implementation of the proposed security fix. Imagine you are describing it to a NASA engineer._

By sending things like 22/03/2021'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt> as a value to a spoon date for instance the popup was shown and the XSS attack would be performed just by loading the page
### 🐛 Proof of Concept (PoC) *

_Provide the vulnerability exploit to show the security issue you're fixing._

Video POC: https://drive.google.com/file/d/1vDjgFCvTuWJq1gPuusVz-7SKaK6icYsq/view?usp=sharing

### 🔥 Proof of Fix (PoF) *

_Replay the vulnerability exploit to show the successful fix and mitigation of the vulnerability._
The alert is no longer showing
<img width="1104" alt="Screenshot 2021-03-23 at 22 28 56" src="https://user-images.githubusercontent.com/3634654/112221011-38d49080-8c27-11eb-8e1d-50819f31e816.png">

### 👍 User Acceptance Testing (UAT)

_Run a unit test or a legitimate use case to prove that your fix does not introduce breaking changes._
I ran the exact same attack where the library is used and it didn't show the popup anymore